### PR TITLE
[35기 개발섬] cart 장바구니 구현

### DIFF
--- a/carts/urls.py
+++ b/carts/urls.py
@@ -4,5 +4,7 @@ from django.views import View
 from carts.views import CartView
 
 urlpatterns = [
-    path('', CartView.as_view())
+    path('', CartView.as_view()),
+    path('/<int:cart_id>', CartView.as_view())
+
 ]

--- a/carts/urls.py
+++ b/carts/urls.py
@@ -1,9 +1,7 @@
 from django.urls import path
 
-from carts.views import CartView, CartToOrderView
+from carts.views import CartView
 
 urlpatterns = [
-    path('', CartView.as_view()),
-    path('/<int:cart_id>', CartView.as_view()),
-    path('/neworder', CartToOrderView.as_view())
+    path('', CartView.as_view())
 ]

--- a/carts/urls.py
+++ b/carts/urls.py
@@ -1,10 +1,8 @@
 from django.urls import path
-from django.views import View
 
 from carts.views import CartView
 
 urlpatterns = [
     path('', CartView.as_view()),
     path('/<int:cart_id>', CartView.as_view())
-
 ]

--- a/carts/urls.py
+++ b/carts/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from carts.views import CartView
+from carts.views import CartView, CartToOrderView
 
 urlpatterns = [
     path('', CartView.as_view()),
-    path('/<int:cart_id>', CartView.as_view())
+    path('/<int:cart_id>', CartView.as_view()),
+    path('/neworder', CartToOrderView.as_view())
 ]

--- a/carts/urls.py
+++ b/carts/urls.py
@@ -1,4 +1,8 @@
 from django.urls import path
+from django.views import View
+
+from carts.views import CartView
 
 urlpatterns = [
+    path('', CartView.as_view())
 ]

--- a/carts/views.py
+++ b/carts/views.py
@@ -79,6 +79,3 @@ class CartView(View):
 
         except Cart.DoesNotExist:
             return JsonResponse({'message':'JSONDecodeError'}, status=404)
-
-        except json.JSONDecodeError:
-            return JsonResponse({'message':'JSONDecodeError'}, status=404)

--- a/carts/views.py
+++ b/carts/views.py
@@ -26,7 +26,7 @@ class CartView(View):
             if not created:
                 cart.quantity += quantity
                 cart.save()
-                return JsonResponse({"message" : "CART_QUANTITY_INCREASED"}, status=200)
+                return JsonResponse({"message" : "CART_QUANTITY_CHANGED"}, status=200)
             
             return JsonResponse({"message" : "PUT_IN_CART_SUCCESS"}, status=201)
 

--- a/carts/views.py
+++ b/carts/views.py
@@ -37,7 +37,7 @@ class CartView(View):
             'price'       : cart.product.price,
             'images'      : [image.image_url for image in cart.product.productimage_set.all()]}
             for cart in Cart.objects.filter(user=request.user)]
-        return JsonResponse({"cart" : cart_products}, status=200)
+        return JsonResponse({"message" : "SUCCESS", "cart" : cart_products}, status=200)
     
     @signin_decorator
     def delete(self, request, cart_id):

--- a/carts/views.py
+++ b/carts/views.py
@@ -72,7 +72,7 @@ class CartView(View):
             
             cart_product.quantity += data['quantity']
             cart_product.save()
-            return JsonResponse({"message" : "UPDATE_SUCCESS"})
+            return JsonResponse({"message" : "UPDATE_SUCCESS"}, status=200)
 
         except KeyError:
             return JsonResponse({"message" : "KEY_ERROR"}, status=400)

--- a/carts/views.py
+++ b/carts/views.py
@@ -6,6 +6,8 @@ from django.views    import View
 from carts.models    import Cart
 from users.utils     import signin_decorator
 from products.models import Product
+from orders.models   import Order, OrderProduct
+
 
 class CartView(View):
     @signin_decorator
@@ -32,6 +34,7 @@ class CartView(View):
     @signin_decorator
     def get(self, request):
         cart_products = [{
+            'id'          : cart.id,
             'product_name': cart.product.name,
             'quantity'    : cart.quantity,
             'price'       : cart.product.price,
@@ -74,3 +77,31 @@ class CartView(View):
 
         except json.JSONDecodeError:
             return JsonResponse({'message':'JSONDecodeError'}, status=404)
+
+class CartToOrder(View):
+    @signin_decorator
+    def post(self, request):
+        try:
+            data     = json.loads(request.body)
+            carts_id = data['carts_id']
+            
+            order = Order.objects.create(
+                order_status_id = 1,
+                user_id         = request.user.id
+            )
+
+            for cart_id in carts_id:
+                cart = Cart.objects.get(id=cart_id)
+                OrderProduct.objects.create(
+                    order_id                = order.id,
+                    product_id              = cart.product.id,
+                    quantity                = cart.quantity,
+                    order_product_status_id = 1
+                )
+            return JsonResponse({"message" : "ORDER_SUCCESS"}, status=201)
+        
+        except KeyError:
+            return JsonResponse({"message" : "KEY_ERROR"}, status=400)
+        
+        except json.JSONDecodeError:
+            return JsonResponse({'message' : 'JSONDecodeError'}, status=404)

--- a/carts/views.py
+++ b/carts/views.py
@@ -16,18 +16,16 @@ class CartView(View):
             data     = json.loads(request.body)
             quantity = data['quantity']
             product  = Product.objects.get(id=data['product_id'])
-            
+
             cart, created = Cart.objects.get_or_create(
-                defaults  = {'quantity': quantity},
+                defaults  = {'quantity' : quantity},
                 product   = product,
                 user      = request.user
             )
-
             if not created:
                 cart.quantity += quantity
                 cart.save()
                 return JsonResponse({"message" : "CART_QUANTITY_CHANGED"}, status=200)
-            
             return JsonResponse({"message" : "PUT_IN_CART_SUCCESS"}, status=201)
 
         except KeyError:
@@ -54,8 +52,7 @@ class CartView(View):
     def delete(self, request):
         try:
             data = json.loads(request.body)
-            for cart_id in data['carts_id']:
-                Cart.objects.filter(user=request.user, id=cart_id).delete()
+            Cart.objects.filter(user=request.user, id__in=data['cart_ids']).delete()
             return JsonResponse({"message":"DELETE_SUCCESS"}, status=200)
 
         except json.JSONDecodeError:
@@ -63,3 +60,25 @@ class CartView(View):
         
         except KeyError:
             return JsonResponse({"message" : "KEY_ERROR"}, status=400)
+
+    @signin_decorator
+    def patch(self, request):
+        try: 
+            data         = json.loads(request.body)
+            cart_product = Cart.objects.get(user=request.user, id=data['cart_id'])
+            
+            if cart_product.product.stock < cart_product.quantity + data['quantity']:
+                return JsonResponse({"message" : "OUT_OF_STOCK"}, status=400)
+            
+            cart_product.quantity += data['quantity']
+            cart_product.save()
+            return JsonResponse({"message" : "UPDATE_SUCCESS"})
+
+        except KeyError:
+            return JsonResponse({"message" : "KEY_ERROR"}, status=400)
+
+        except Cart.DoesNotExist:
+            return JsonResponse({'message':'JSONDecodeError'}, status=404)
+
+        except json.JSONDecodeError:
+            return JsonResponse({'message':'JSONDecodeError'}, status=404)

--- a/carts/views.py
+++ b/carts/views.py
@@ -16,22 +16,19 @@ class CartView(View):
             data     = json.loads(request.body)
             quantity = data['quantity']
             product  = Product.objects.get(id=data['product_id'])
-            user     = request.user
             
             cart, created = Cart.objects.get_or_create(
-                defaults  = {'quantity': 0},
+                defaults  = {'quantity': quantity},
                 product   = product,
-                user      = user
+                user      = request.user
             )
-            cart.quantity += quantity
-            cart.save()
 
-            if created == True:
-                return JsonResponse({"message" : "PUT_IN_CART_SUCCESS"}, status=201)
+            if not created:
+                cart.quantity += quantity
+                cart.save()
+                return JsonResponse({"message" : "CART_QUANTITY_INCREASED"}, status=200)
             
-            return JsonResponse({"message" : "CART_QUANTITY_INCREASED"}, status=200)
-
-            
+            return JsonResponse({"message" : "PUT_IN_CART_SUCCESS"}, status=201)
 
         except KeyError:
             return JsonResponse({"message" : "KEY_ERROR"}, status=400)

--- a/carts/views.py
+++ b/carts/views.py
@@ -18,20 +18,20 @@ class CartView(View):
             product  = Product.objects.get(id=data['product_id'])
             user     = request.user
             
-            if Cart.objects.filter(product_id = product.id).exists():
-                cart_product = Cart.objects.get(user=request.user, product_id=product.id)
-                if cart_product.product.stock < cart_product.quantity + quantity:
-                    return JsonResponse({"message" : "OUT_OF_STOCK"}, status=400)
-                cart_product.quantity += quantity
-                cart_product.save()
-                return JsonResponse({"message" : "CART_QUANTITY_INCREASED"}, status=200)
-
-            Cart.objects.create(
-                quantity = quantity,
-                product  = product,
-                user     = user
+            cart, created = Cart.objects.get_or_create(
+                defaults  = {'quantity': 0},
+                product   = product,
+                user      = user
             )
-            return JsonResponse({"message" : "PUT_IN_CART_SUCCESS"}, status=201)
+            cart.quantity += quantity
+            cart.save()
+
+            if created == True:
+                return JsonResponse({"message" : "PUT_IN_CART_SUCCESS"}, status=201)
+            
+            return JsonResponse({"message" : "CART_QUANTITY_INCREASED"}, status=200)
+
+            
 
         except KeyError:
             return JsonResponse({"message" : "KEY_ERROR"}, status=400)

--- a/carts/views.py
+++ b/carts/views.py
@@ -35,9 +35,10 @@ class CartView(View):
     @signin_decorator
     def get(self, request):
         cart_products = [{
-            'product_name' : cart.product.name,
-            'quantity'     : cart.quantity,
-            'price'        : cart.product.price}
+            'product_name' : cart.product.name, 
+            'quantity':cart.quantity, 
+            'price':cart.product.price, 
+            'images':[image.image_url for image in cart.product.productimage_set.all()]}
             for cart in Cart.objects.filter(user=request.user)]
         return JsonResponse({"cart" : cart_products}, status=200)
     

--- a/carts/views.py
+++ b/carts/views.py
@@ -65,4 +65,3 @@ class CartView(View):
 
         except json.JSONDecodeError:
             return JsonResponse({'message':'JSONDecodeError'}, status=404)
-

--- a/carts/views.py
+++ b/carts/views.py
@@ -1,3 +1,38 @@
-from django.shortcuts import render
+import json
 
-# Create your views here.
+from django.http     import JsonResponse
+from django.views    import View
+
+from carts.models    import Cart
+from users.utils     import signin_decorator
+from users.views     import LogInView
+from products.models import Product
+from users.models    import User
+
+
+class CartView(View):
+    @signin_decorator
+    def post(self, request):
+        try:
+            data = json.loads(request.body)
+            quantity = data['quantity']
+            product = Product.objects.get(id=data['product_id'])
+            user = request.user
+            
+            Cart.objects.create(
+                quantity = quantity,
+                product = product,
+                user = user
+            )
+            return JsonResponse({"message" : "SUCCESS"}, status=201)
+
+        except KeyError:
+            return JsonResponse({"message" : "KEY_ERROR"}, status=400)
+        
+        except json.JSONDecodeError:
+            return JsonResponse({'message':'JSONDecodeError'}, status=404)
+
+    @signin_decorator
+    def get(self, request):
+        cart_products = [[cart.product.name, cart.quantity, cart.product.price] for cart in Cart.objects.filter(user=request.user)]
+        return JsonResponse({"cart" : cart_products}, status=200)

--- a/carts/views.py
+++ b/carts/views.py
@@ -5,10 +5,7 @@ from django.views    import View
 
 from carts.models    import Cart
 from users.utils     import signin_decorator
-from users.views     import LogInView
 from products.models import Product
-from users.models    import User
-
 
 class CartView(View):
     @signin_decorator
@@ -35,10 +32,10 @@ class CartView(View):
     @signin_decorator
     def get(self, request):
         cart_products = [{
-            'product_name' : cart.product.name, 
-            'quantity':cart.quantity, 
-            'price':cart.product.price, 
-            'images':[image.image_url for image in cart.product.productimage_set.all()]}
+            'product_name': cart.product.name,
+            'quantity'    : cart.quantity,
+            'price'       : cart.product.price,
+            'images'      : [image.image_url for image in cart.product.productimage_set.all()]}
             for cart in Cart.objects.filter(user=request.user)]
         return JsonResponse({"cart" : cart_products}, status=200)
     

--- a/carts/views.py
+++ b/carts/views.py
@@ -30,9 +30,6 @@ class CartView(View):
 
         except KeyError:
             return JsonResponse({"message" : "KEY_ERROR"}, status=400)
-
-        except Cart.DoesNotExist:
-            return JsonResponse({'message':'JSONDecodeError'}, status=404)
         
         except json.JSONDecodeError:
             return JsonResponse({'message':'JSONDecodeError'}, status=404)

--- a/carts/views.py
+++ b/carts/views.py
@@ -36,3 +36,9 @@ class CartView(View):
     def get(self, request):
         cart_products = [[cart.product.name, cart.quantity, cart.product.price] for cart in Cart.objects.filter(user=request.user)]
         return JsonResponse({"cart" : cart_products}, status=200)
+    
+    @signin_decorator
+    def delete(self, request, cart_id):
+        if Cart.objects.filter(user=request.user, id=cart_id).delete()[0]:
+            return JsonResponse({"message":"SUCCESS"}, status=200)
+        return JsonResponse({"message":"텅"}, status=400)

--- a/carts/views.py
+++ b/carts/views.py
@@ -40,10 +40,19 @@ class CartView(View):
         return JsonResponse({"message" : "SUCCESS", "cart" : cart_products}, status=200)
     
     @signin_decorator
-    def delete(self, request, cart_id):
-        Cart.objects.filter(user=request.user, id=cart_id).delete()
-        return JsonResponse({"message":"DELETE_SUCCESS"}, status=200)
+    def delete(self, request):
+        try:
+            data = json.loads(request.body)
+            for cart_id in data['carts_id']:
+                Cart.objects.filter(user=request.user, id=cart_id).delete()
+            return JsonResponse({"message":"DELETE_SUCCESS"}, status=200)
 
+        except json.JSONDecodeError:
+            return JsonResponse({'message':'JSONDecodeError'}, status=404)
+        
+        except KeyError:
+            return JsonResponse({"message" : "KEY_ERROR"}, status=400)
+        
     @signin_decorator
     def patch(self, request, cart_id):
         try: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mysqlclient==2.1.1
 PyMySQL==1.0.2
 bcrypt==3.2.2
 jwt==1.3.1
+PyJWT==2.4.0

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,0 +1,27 @@
+import json
+
+import bcrypt
+import jwt
+from django.http            import JsonResponse
+from django.views           import View
+from django.conf            import settings
+
+from users.models     import User
+
+def signin_decorator(func):
+    def wrapper(self, request, *args, **kwargs):
+        try:
+            access_token = request.headers.get('Authorization', None)
+            payload = jwt.decode(access_token, settings.SECRET_KEY, algorithms=settings.ALGORITHM)
+            user = User.objects.get(id=payload['id'])
+            request.user = user
+
+        except jwt.exceptions.DecodeError:
+            return JsonResponse({'message':'INVALID_TOKEN'}, status=400)
+        
+        except User.DoesNotExist:
+            return JsonResponse({'message':'INVALID_USER'}, status=400)
+
+        return func(self, request, *args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 장바구니 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 장바구니 post 구현
- quantity와 product_id를 request.body로 받아 request.user의 장바구니 생성
- KeyError, JSONDecodeError 에러 처리 구현
2. 장바구니 get 구현
- request.user의 cart 정보를 담아 반환
3. 장바구니 delete 구현
- url로 cart_id를 받아, request.user의 cart_id를 삭제
4. 장바구니 patch 구현
- requets.body로 stock을 받아 재고량 이내의 update일 시엔 cart의 quantity 변경
- 재고 초과시 OUT_OF_STOCK 반환
- KeyError, DoesNotExist, JSONDecodeError 에러 처리 구현

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
없습니다.
<br />

## :: 기타 질문 및 특이 사항
없습니다.